### PR TITLE
[qmf] onlineMoveFolder implementation. Contributes to JB#41524

### DIFF
--- a/src/libraries/qmfclient/qmailaction.h
+++ b/src/libraries/qmfclient/qmailaction.h
@@ -65,7 +65,8 @@ enum QMailServerRequestType
     SearchMessagesRequestType,
     CancelSearchRequestType,
     ListActionsRequestType,
-    ProtocolRequestRequestType
+    ProtocolRequestRequestType,
+    MoveFolderRequestType
 };
 
 typedef quint64 QMailActionId;

--- a/src/libraries/qmfclient/qmailmessageserver.h
+++ b/src/libraries/qmfclient/qmailmessageserver.h
@@ -89,6 +89,7 @@ Q_SIGNALS:
     void folderCreated(quint64, const QMailFolderId&);
     void folderRenamed(quint64, const QMailFolderId&);
     void folderDeleted(quint64, const QMailFolderId&);
+    void folderMoved(quint64, const QMailFolderId&);
 
     void storageActionCompleted(quint64);
 
@@ -140,6 +141,7 @@ public Q_SLOTS:
     void onlineCreateFolder(quint64, const QString &name, const QMailAccountId &accountId, const QMailFolderId &parentId);
     void onlineRenameFolder(quint64, const QMailFolderId &folderId, const QString &name);
     void onlineDeleteFolder(quint64, const QMailFolderId &folderId);
+    void onlineMoveFolder(quint64, const QMailFolderId &folderId, const QMailFolderId &newParentId);
 
     void deleteMessages(quint64, const QMailMessageIdList &ids);
     void rollBackUpdates(quint64, const QMailAccountId &mailAccountId);

--- a/src/libraries/qmfclient/qmailserviceaction.cpp
+++ b/src/libraries/qmfclient/qmailserviceaction.cpp
@@ -1681,6 +1681,12 @@ void QMailStorageActionPrivate::onlineDeleteFolder(const QMailFolderId &folderId
     onlineDeleteFolderHelper(folderId);
 }
 
+void QMailStorageActionPrivate::onlineMoveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId)
+{
+    _server->onlineMoveFolder(newAction(), folderId, newParentId);
+    emitChanges();
+}
+
 void QMailStorageActionPrivate::init()
 {
     QMailServiceActionPrivate::init();
@@ -2016,6 +2022,20 @@ void QMailStorageAction::onlineRenameFolder(const QMailFolderId &folderId, const
 void QMailStorageAction::onlineDeleteFolder(const QMailFolderId &folderId)
 {
     impl(this)->onlineDeleteFolder(folderId);
+}
+
+/*!
+    Requests that the message server move the folder identified by \a folderId.
+    If \a newParentId is a valid folder identifier the folder will be a child of the parent;
+    otherwise the folder will be have no parent and will be created at the highest level.
+
+    This function requires the device to be online, it may initiate communication with external servers.
+
+    \sa onlineCreateFolder(), onlineRenameFolder()
+*/
+void QMailStorageAction::onlineMoveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId)
+{
+    impl(this)->onlineMoveFolder(folderId, newParentId);
 }
 
 

--- a/src/libraries/qmfclient/qmailserviceaction.h
+++ b/src/libraries/qmfclient/qmailserviceaction.h
@@ -244,6 +244,7 @@ public Q_SLOTS:
     void onlineCreateFolder(const QString &name, const QMailAccountId &accountId, const QMailFolderId &parentId);
     void onlineRenameFolder(const QMailFolderId &folderId, const QString &name);
     void onlineDeleteFolder(const QMailFolderId &folderId);
+    void onlineMoveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId);
 
     void deleteMessages(const QMailMessageIdList &ids);
     void rollBackUpdates(const QMailAccountId &mailAccountId);

--- a/src/libraries/qmfclient/qmailserviceaction_p.h
+++ b/src/libraries/qmfclient/qmailserviceaction_p.h
@@ -270,6 +270,7 @@ public:
     void onlineRenameFolder(const QMailFolderId &id, const QString &name);
     void onlineDeleteFolder(const QMailFolderId &id);
     void onlineDeleteFolderHelper(const QMailFolderId &id);
+    void onlineMoveFolder(const QMailFolderId &id, const QMailFolderId &newParentId);
 
 protected:
     virtual void init();

--- a/src/libraries/qmfmessageserver/qmailmessageservice.cpp
+++ b/src/libraries/qmfmessageserver/qmailmessageservice.cpp
@@ -863,7 +863,24 @@ bool QMailMessageSource::deleteFolder(const QMailFolderId &folderId)
     return false;
 }
 
+/*!
+    Invoked by the message server to move a folder.
 
+    Moves the folder identified by \a folderId to a folder idnetified by \a newParentId.
+    The name of the folder should not change.
+
+    Return true if an operation is initiated.
+
+    \sa deleteFolder(), createFolder(), renameFolder()
+*/
+bool QMailMessageSource::moveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId)
+{
+    Q_UNUSED(folderId)
+    Q_UNUSED(newParentId)
+
+    notImplemented();
+    return false;
+}
 
 /*!
     Invoked by the message server to initiate a remote message search operation.
@@ -1909,6 +1926,23 @@ bool QMailMessageSource::renameFolder(const QMailFolderId &folderId, const QStri
 bool QMailMessageSource::deleteFolder(const QMailFolderId &folderId, quint64 action)
 {
     Q_UNUSED(folderId)
+    Q_UNUSED(action)
+
+    notImplemented(action);
+    return false;
+}
+
+/*!
+    \overload moveFolder()
+
+    Concurrent version of moveFolder().
+
+    The request has the identifier \a action.
+*/
+bool QMailMessageSource::moveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId, quint64 action)
+{
+    Q_UNUSED(folderId)
+    Q_UNUSED(newParentId)
     Q_UNUSED(action)
 
     notImplemented(action);

--- a/src/libraries/qmfmessageserver/qmailmessageservice.h
+++ b/src/libraries/qmfmessageserver/qmailmessageservice.h
@@ -164,6 +164,8 @@ public Q_SLOTS:
     virtual bool renameFolder(const QMailFolderId &folderId, const QString &name, quint64 action);
     virtual bool deleteFolder(const QMailFolderId &folderId);
     virtual bool deleteFolder(const QMailFolderId &folderId, quint64 action);
+    virtual bool moveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId);
+    virtual bool moveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId, quint64 action);
 
     virtual bool searchMessages(const QMailMessageKey &filter, const QString& bodyText, quint64 limit, const QMailMessageSortKey &sort);
     virtual bool searchMessages(const QMailMessageKey &filter, const QString& bodyText, quint64 limit, const QMailMessageSortKey &sort, quint64 action);

--- a/src/plugins/messageservices/imap/imap.pro
+++ b/src/plugins/messageservices/imap/imap.pro
@@ -19,7 +19,8 @@ HEADERS += imapclient.h \
            imapstrategy.h \
            integerregion.h \
            imaptransport.h \
-           serviceactionqueue.h
+           serviceactionqueue.h \
+           imapfoldernamecoding.h
 
 SOURCES += imapclient.cpp \
            imapconfiguration.cpp \
@@ -30,7 +31,8 @@ SOURCES += imapclient.cpp \
            imapstrategy.cpp \
            integerregion.cpp \
            imaptransport.cpp \
-           serviceactionqueue.cpp
+           serviceactionqueue.cpp \
+           imapfoldernamecoding.cpp
 
 !contains(DEFINES,QMF_NO_MESSAGE_SERVICE_EDITOR) {
     QT += gui widgets

--- a/src/plugins/messageservices/imap/imapclient.h
+++ b/src/plugins/messageservices/imap/imapclient.h
@@ -128,9 +128,10 @@ public slots:
     void messageCreated(const QMailMessageId &, const QString &);
     void downloadSize(const QString &uid, int);
     void urlAuthorized(const QString &url);
-    void folderDeleted(const QMailFolder &folder);
-    void folderCreated(const QString &folder);
-    void folderRenamed(const QMailFolder &folder, const QString &newName);
+    void folderDeleted(const QMailFolder &folder, bool success);
+    void folderCreated(const QString &folder, bool success);
+    void folderRenamed(const QMailFolder &folder, const QString &newName, bool success);
+    void folderMoved(const QMailFolder &folder, const QString &newName, const QMailFolderId &newParentId, bool success);
 
 protected slots:
     void connectionInactive();

--- a/src/plugins/messageservices/imap/imapfoldernamecoding.cpp
+++ b/src/plugins/messageservices/imap/imapfoldernamecoding.cpp
@@ -1,0 +1,236 @@
+#include "imapfoldernamecoding.h"
+
+#include <qstring.h>
+#include <qlist.h>
+
+QString encodeModifiedBase64(QString in)
+{
+    // Modified Base64 chars pattern
+    const QString encodingSchema = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,";
+
+    QString result;
+
+    QList<ushort> buf;
+    unsigned short tmp;
+    int i;
+
+    // chars to numeric
+    for(i = 0; i < in.length(); i++){
+        buf.push_back(in[i].unicode());
+    }
+
+    // adding &
+    result.push_back('&');
+
+    i = 0;
+
+    // encode every 6 bits separately in pattern by 3 symbols
+    while(i < buf.length()){
+
+        result.push_back(encodingSchema[(buf[i] & 0xfc00) >> 10]);
+
+        result.push_back(encodingSchema[(buf[i] & 0x3f0) >> 4]);
+
+        tmp = 0;
+        tmp |= ((buf[i] & 0xf) << 12);
+        if (i + 1 < buf.length())
+        {
+            i++;
+            tmp |= ((buf[i] & 0xc000) >> 4);
+            result.push_back(encodingSchema[tmp >> 10]);
+        } else {
+            result.push_back(encodingSchema[tmp >> 10]);
+            break;
+        }
+
+        result.push_back(encodingSchema[(buf[i] & 0x3f00) >> 8]);
+
+        result.push_back(encodingSchema[(buf[i] & 0xfc) >> 2]);
+
+        tmp = 0;
+        tmp |= ((buf[i] & 0x3) << 14);
+        if (i + 1 < buf.length())
+        {
+            i++;
+            tmp |= ((buf[i] & 0xf000) >> 2);
+            result.push_back(encodingSchema[tmp >> 10]);
+        } else {
+            result.push_back(encodingSchema[tmp >> 10]);
+            break;
+        }
+
+        result.push_back(encodingSchema[(buf[i] & 0xfc0) >> 6]);
+
+        result.push_back(encodingSchema[buf[i] & 0x3f]);
+
+        i++;
+    }
+
+    // adding -
+    result.push_back('-');
+
+    return result;
+}
+
+QString encodeModUTF7(QString in)
+{
+    int startIndex = 0;
+    int endIndex = 0;
+
+    while (startIndex < in.length())
+    {
+        // insert '_' after '&'
+        if (in[startIndex] == '&')
+        {
+            startIndex++;
+            in.insert(startIndex, '-');
+            continue;
+        }
+
+        if (in[startIndex].unicode() < 0x20 || in[startIndex].unicode() > 0x7e)
+        {
+            // get non-US-ASCII part
+            endIndex = startIndex;
+            while(endIndex < in.length() && (in[endIndex].unicode() < 0x20 || in[endIndex].unicode() > 0x7e))
+                endIndex++;
+
+            // encode non-US-ASCII part
+            QString unicodeString = in.mid(startIndex,(endIndex - startIndex));
+            QString mbase64 = encodeModifiedBase64(unicodeString);
+
+            // insert the encoded string
+            in.remove(startIndex,(endIndex-startIndex));
+            in.insert(startIndex, mbase64);
+
+            // set start index to the end of the encoded part
+            startIndex += mbase64.length() - 1;
+        }
+        startIndex++;
+    }
+    return in;
+}
+
+QString encodeFolderName(const QString &name)
+{
+        return encodeModUTF7(name);
+}
+
+QString decodeModifiedBase64(QString in)
+{
+    //remove  & -
+    in.remove(0,1);
+    in.remove(in.length()-1,1);
+
+    if(in.isEmpty())
+        return "&";
+
+    QByteArray buf(in.length(),static_cast<char>(0));
+    QByteArray out(in.length() * 3 / 4 + 2,static_cast<char>(0));
+
+    //chars to numeric
+    QByteArray latinChars = in.toLatin1();
+    for (int x = 0; x < in.length(); x++) {
+        int c = latinChars[x];
+        if ( c >= 'A' && c <= 'Z')
+            buf[x] = c - 'A';
+        if ( c >= 'a' && c <= 'z')
+            buf[x] = c - 'a' + 26;
+        if ( c >= '0' && c <= '9')
+            buf[x] = c - '0' + 52;
+        if ( c == '+')
+            buf[x] = 62;
+        if ( c == ',')
+            buf[x] = 63;
+    }
+
+    int i = 0; //in buffer index
+    int j = i; //out buffer index
+
+    unsigned char z;
+    QString result;
+
+    while(i+1 < buf.size())
+    {
+        out[j] = buf[i] & (0x3F); //mask out top 2 bits
+        out[j] = out[j] << 2;
+        z = buf[i+1] >> 4;
+        out[j] = (out[j] | z);      //first byte retrieved
+
+        i++;
+        j++;
+
+        if(i+1 >= buf.size())
+            break;
+
+        out[j] = buf[i] & (0x0F);   //mask out top 4 bits
+        out[j] = out[j] << 4;
+        z = buf[i+1] >> 2;
+        z &= 0x0F;
+        out[j] = (out[j] | z);      //second byte retrieved
+
+        i++;
+        j++;
+
+        if(i+1 >= buf.size())
+            break;
+
+        out[j] = buf[i] & 0x03;   //mask out top 6 bits
+        out[j] = out[j] <<  6;
+        z = buf[i+1];
+        out[j] = out[j] | z;  //third byte retrieved
+
+        i+=2; //next byte
+        j++;
+    }
+
+    //go through the buffer and extract 16 bit unicode network byte order
+    for(int z = 0; z < out.count(); z+=2) {
+        unsigned short outcode = 0x0000;
+        outcode = out[z];
+        outcode <<= 8;
+        outcode &= 0xFF00;
+
+        unsigned short b = 0x0000;
+        b = out[z+1];
+        b &= 0x00FF;
+        outcode = outcode | b;
+        if(outcode)
+            result += QChar(outcode);
+    }
+
+    return result;
+}
+
+QString decodeModUTF7(QString in)
+{
+    QRegExp reg("&[^&-]*-");
+
+    int startIndex = 0;
+    int endIndex = 0;
+
+    startIndex = in.indexOf(reg,endIndex);
+    while (startIndex != -1) {
+        endIndex = startIndex;
+        while(endIndex < in.length() && in[endIndex] != '-')
+            endIndex++;
+        endIndex++;
+
+        //extract the base64 string from the input string
+        QString mbase64 = in.mid(startIndex,(endIndex - startIndex));
+        QString unicodeString = decodeModifiedBase64(mbase64);
+
+        //remove encoding
+        in.remove(startIndex,(endIndex-startIndex));
+        in.insert(startIndex,unicodeString);
+
+        endIndex = startIndex + unicodeString.length();
+        startIndex = in.indexOf(reg,endIndex);
+    }
+
+    return in;
+}
+
+QString decodeFolderName(const QString &name)
+{
+    return decodeModUTF7(name);
+}

--- a/src/plugins/messageservices/imap/imapfoldernamecoding.h
+++ b/src/plugins/messageservices/imap/imapfoldernamecoding.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 TBD
+** Contact: TBD
+**
+** This file is part of the Qt Messaging Framework.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef IMAPFOLDERNAMECODING_H
+#define IMAPFOLDERNAMECODING_H
+
+#include <qstring.h>
+
+QString encodeFolderName(const QString &name);
+
+QString decodeFolderName(const QString &name);
+
+#endif
+

--- a/src/plugins/messageservices/imap/imapprotocol.h
+++ b/src/plugins/messageservices/imap/imapprotocol.h
@@ -83,7 +83,8 @@ enum ImapCommand
     IMAP_QResync,
     IMAP_FetchFlags,
     IMAP_Noop,
-    IMAP_Compress
+    IMAP_Compress,
+    IMAP_Move
 };
 
 enum MessageFlag
@@ -186,6 +187,7 @@ public:
     void sendCreate(const QMailFolderId &parentFolderId, const QString &name);
     void sendDelete(const QMailFolder &mailbox);
     void sendRename(const QMailFolder &mailbox, const QString &newname);
+    void sendMove(const QMailFolder &mailbox, const QMailFolderId &newParentId);
 
     /*  Valid in Selected state only */
     void sendSearchMessages(const QMailMessageKey &key, const QString &body, const QMailMessageSortKey &sort, bool count);
@@ -213,6 +215,7 @@ public:
 
     static QString quoteString(const QString& input);
     static QByteArray quoteString(const QByteArray& input);
+    static QString unescapeFolderPath(const QString &path);
 
 signals:
     void mailboxListed(const QString &flags, const QString &name);
@@ -225,9 +228,10 @@ signals:
     void messageCreated(const QMailMessageId& id, const QString& uid);
     void urlAuthorized(const QString& url);
 
-    void folderCreated(const QString &folder);
-    void folderDeleted(const QMailFolder &name);
-    void folderRenamed(const QMailFolder &folder, const QString &newPath);
+    void folderCreated(const QString &folder, bool success);
+    void folderDeleted(const QMailFolder &name, bool success);
+    void folderRenamed(const QMailFolder &folder, const QString &newPath, bool success);
+    void folderMoved(const QMailFolder &folder, const QString &newPath, const QMailFolderId &newParentId, bool success);
 
     void continuationRequired(ImapCommand, const QString &);
     void completed(ImapCommand, OperationStatus);

--- a/src/plugins/messageservices/imap/imapservice.cpp
+++ b/src/plugins/messageservices/imap/imapservice.cpp
@@ -145,6 +145,7 @@ public slots:
     virtual bool createStandardFolders(const QMailAccountId &accountId);
     virtual bool deleteFolder(const QMailFolderId &folderId);
     virtual bool renameFolder(const QMailFolderId &folderId, const QString &name);
+    virtual bool moveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId);
 
     virtual bool searchMessages(const QMailMessageKey &searchCriteria, const QString &bodyText, const QMailMessageSortKey &sort);
     virtual bool searchMessages(const QMailMessageKey &searchCriteria, const QString &bodyText, quint64 limit, const QMailMessageSortKey &sort);
@@ -1085,6 +1086,32 @@ bool ImapService::Source::renameFolder(const QMailFolderId &folderId, const QStr
     appendStrategy(&_service->_client->strategyContext()->renameFolderStrategy);
     if(!_unavailable)
         return initiateStrategy();
+    return true;
+}
+
+bool ImapService::Source::moveFolder(const QMailFolderId &folderId, const QMailFolderId &newParentId)
+{
+    Q_ASSERT(!_unavailable);
+    if (!_service)
+        return false;
+
+    if (!_service->_client) {
+        _service->errorOccurred(QMailServiceAction::Status::ErrFrameworkFault, tr("Account disabled"));
+        return false;
+    }
+
+    if(!folderId.isValid()) {
+        _service->errorOccurred(QMailServiceAction::Status::ErrInvalidData, tr("Cannot move an invalid folder"));
+        return false;
+    }
+
+    _service->_client->strategyContext()->moveFolderStrategy.moveFolder(folderId, newParentId);
+
+    appendStrategy(&_service->_client->strategyContext()->moveFolderStrategy);
+
+    if(!_unavailable)
+        return initiateStrategy();
+
     return true;
 }
 

--- a/src/tools/messageserver/mailmessageclient.cpp
+++ b/src/tools/messageserver/mailmessageclient.cpp
@@ -79,7 +79,9 @@ MailMessageClient::MailMessageClient(QObject* parent)
                adaptor, MESSAGE(folderCreated(quint64, QMailFolderId)));
     connectIpc(this, SIGNAL(folderRenamed(quint64, QMailFolderId)), 
                adaptor, MESSAGE(folderRenamed(quint64, QMailFolderId)));
-    connectIpc(this, SIGNAL(folderDeleted(quint64, QMailFolderId)), 
+    connectIpc(this, SIGNAL(folderMoved(quint64, QMailFolderId)),
+               adaptor, MESSAGE(folderMoved(quint64, QMailFolderId)));
+    connectIpc(this, SIGNAL(folderDeleted(quint64, QMailFolderId)),
                adaptor, MESSAGE(folderDeleted(quint64, QMailFolderId)));
     connectIpc(this, SIGNAL(storageActionCompleted(quint64)), 
                adaptor, MESSAGE(storageActionCompleted(quint64)));
@@ -160,6 +162,8 @@ MailMessageClient::MailMessageClient(QObject* parent)
                this, SIGNAL(onlineRenameFolder(quint64,QMailFolderId,QString)));
     connectIpc(adaptor, MESSAGE(onlineDeleteFolder(quint64, QMailFolderId)),
                this, SIGNAL(onlineDeleteFolder(quint64,QMailFolderId)));
+    connectIpc(adaptor, MESSAGE(onlineMoveFolder(quint64, QMailFolderId, QMailFolderId)),
+               this, SIGNAL(onlineMoveFolder(quint64,QMailFolderId,QMailFolderId)));
     connectIpc(adaptor, MESSAGE(cancelTransfer(quint64)),
                this, SIGNAL(cancelTransfer(quint64)));
     connectIpc(adaptor, MESSAGE(cancelSearch(quint64)),

--- a/src/tools/messageserver/mailmessageclient.h
+++ b/src/tools/messageserver/mailmessageclient.h
@@ -99,6 +99,7 @@ signals:
     void onlineCreateFolder(quint64, const QString &name, const QMailAccountId &accountId, const QMailFolderId &parentId);
     void onlineRenameFolder(quint64, const QMailFolderId &folderId, const QString &name);
     void onlineDeleteFolder(quint64, const QMailFolderId &folderId);
+    void onlineMoveFolder(quint64, const QMailFolderId &folderId, const QMailFolderId &newParentId);
 
     void cancelTransfer(quint64);
 
@@ -134,6 +135,7 @@ signals:
     
     void folderCreated(quint64, const QMailFolderId&);
     void folderRenamed(quint64, const QMailFolderId&);
+    void folderMoved(quint64, const QMailFolderId&);
     void folderDeleted(quint64, const QMailFolderId&);
     
     void storageActionCompleted(quint64);

--- a/src/tools/messageserver/messageserver.cpp
+++ b/src/tools/messageserver/messageserver.cpp
@@ -128,6 +128,8 @@ MessageServer::MessageServer(QObject *parent)
                 client, SIGNAL(folderCreated(quint64, QMailFolderId)));
         connect(handler, SIGNAL(folderRenamed(quint64, QMailFolderId)),
                 client, SIGNAL(folderRenamed(quint64, QMailFolderId)));
+        connect(handler, SIGNAL(folderMoved(quint64, QMailFolderId)),
+                client, SIGNAL(folderMoved(quint64, QMailFolderId)));
         connect(handler, SIGNAL(folderDeleted(quint64, QMailFolderId)),
                 client, SIGNAL(folderDeleted(quint64, QMailFolderId)));
         connect(handler, SIGNAL(storageActionCompleted(quint64)),
@@ -219,6 +221,8 @@ MessageServer::MessageServer(QObject *parent)
                 handler, SLOT(onlineRenameFolder(quint64, QMailFolderId, QString)));
         connect(client, SIGNAL(onlineDeleteFolder(quint64, QMailFolderId)),
                 handler, SLOT(onlineDeleteFolder(quint64, QMailFolderId)));
+        connect(client, SIGNAL(onlineMoveFolder(quint64, QMailFolderId, QMailFolderId)),
+                handler, SLOT(onlineMoveFolder(quint64, QMailFolderId, QMailFolderId)));
         connect(client, SIGNAL(cancelTransfer(quint64)),
                 handler, SLOT(cancelTransfer(quint64)));
         connect(client, SIGNAL(protocolRequest(quint64, QMailAccountId, QString, QVariant)),

--- a/src/tools/messageserver/servicehandler.h
+++ b/src/tools/messageserver/servicehandler.h
@@ -91,6 +91,7 @@ public slots:
     void onlineCreateFolder(quint64 action, const QString &name, const QMailAccountId &accountId, const QMailFolderId &parentId);
     void onlineRenameFolder(quint64 action, const QMailFolderId &folderId, const QString &name);
     void onlineDeleteFolder(quint64 action, const QMailFolderId &folderId);
+    void onlineMoveFolder(quint64 action, const QMailFolderId &folderId, const QMailFolderId &newParentId);
     void cancelTransfer(quint64 action);
     void searchMessages(quint64 action, const QMailMessageKey &filter, const QString &bodyText, QMailSearchAction::SearchSpecification spec, const QMailMessageSortKey &sort);
     void searchMessages(quint64 action, const QMailMessageKey &filter, const QString &bodyText, QMailSearchAction::SearchSpecification spec, quint64 limit, const QMailMessageSortKey &sort);
@@ -126,6 +127,7 @@ signals:
     void folderCreated(quint64 action, const QMailFolderId&);
     void folderRenamed(quint64 action, const QMailFolderId&);
     void folderDeleted(quint64 action, const QMailFolderId&); 
+    void folderMoved(quint64 action, const QMailFolderId&);
 
     void storageActionCompleted(quint64 action);
 
@@ -265,6 +267,7 @@ private:
     bool dispatchOnlineCreateFolder(quint64 action, const QByteArray &data);
     bool dispatchOnlineDeleteFolder(quint64 action, const QByteArray &data);
     bool dispatchOnlineRenameFolder(quint64 action, const QByteArray &data);
+    bool dispatchOnlineMoveFolder(quint64 action, const QByteArray &data);
     bool dispatchSearchMessages(quint64 action, const QByteArray &data);
     bool dispatchProtocolRequest(quint64 action, const QByteArray &data);
 


### PR DESCRIPTION
Additional fix for ImapClient::mailboxListed: avoid empty folder creations on following IMAP response
* LIST (\Noselect) "/" "/"

Additional fix for 'rename folder': when renaming top level folder - ancestor folder paths were not updated

Additional fix for IMAP (setFolderFlags): for Spam folder, check attributes "\\Spam"
 and "\\Junk" (see rfc6154, Section 2)

Additional fix for IMAP: in case of failure create/delete/rename/move - still need to decrease internal _inProgress counters. Otherwise, after failure - next actions will not ever be completed

Addition for IMAP: don't allow create/rename when name contains IMAP delimiter (e.g. '/').

Additional fix for IMAP: encode folder name on create/rename according to RFC 3501, section 5.1.3. (imapfoldernamecoding.* files)

Additional fix for ImapProtocol::quoteString: fix crash when folder name contains lots of '\\\\\'

Additional fix for 'mailboxListed' - IMAP responses shall be 'unescaped' (in opposite to ImapProtocol::quoteString usage in IMAP requests). This is to handle properly names with " character